### PR TITLE
POMDPTools Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Manifest.toml
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Manifest.toml
 .vscode
+test/gr-temp

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.5.3"
 
 [deps]
 BasicPOMCP = "d721219e-3fc6-5570-a8ef-e5402f47c49e"
-BeliefUpdaters = "8bb6e9a1-7d73-552c-a44a-e5dc5634aac4"
 CPUTime = "a9c8d775-2e2e-55fc-8582-045d282d599e"
 D3Trees = "e3df1716-f71e-5df9-9e2d-98e193103c45"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -13,8 +12,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MCTS = "e12ccd36-dcad-5f33-8774-9175229e7b33"
 POMDPLinter = "f3bd98c0-eb40-45e2-9eb1-f2763262d755"
-POMDPModelTools = "08074719-1b2a-587c-a292-00f91cc44415"
-POMDPSimulators = "e0d0a172-29c6-5d4e-96d0-f262df5d01fd"
+POMDPTools = "7588e00f-9cae-40de-98dc-e0c70c48cdd7"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 ParticleFilters = "c8b314e2-9260-5cf8-ae76-3be7461ca6d0"
@@ -25,17 +23,15 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-BasicPOMCP = "0.3"
-BeliefUpdaters = "0.2"
+BasicPOMCP = "0.3.10"
 CPUTime = "1"
 D3Trees = "0.3"
 Distances = "0.9, 0.10"
 Distributions = "0.22 - 0.25"
-MCTS = "0.4"
+MCTS = "0.5"
 POMDPLinter = "0.1"
-POMDPModelTools = "0.3"
-POMDPSimulators = "0.3"
 POMDPs = "0.9"
+POMDPTools = "0.1"
 Parameters = "0.12"
 ParticleFilters = "0.5"
 Plots = "1"
@@ -44,10 +40,9 @@ julia = "1"
 
 [extras]
 POMDPModels = "355abbd5-f08e-5560-ac9e-8b5f2592a0ca"
-POMDPPolicies = "182e52fb-cfd0-5e46-8c26-fd0667c990f4"
 ProfileView = "c46f51b8-102a-5cf2-8d2c-8597cb0e0da7"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "POMDPModels", "POMDPPolicies", "ProfileView", "ProgressMeter"]
+test = ["Test", "POMDPModels", "ProfileView", "ProgressMeter"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AdaOPS"
 uuid = "eadfb9d8-44f1-454c-a5eb-0663ee7d74a1"
 repo = "git@github.com:LAMDA-POMDP/AdaOPS.jl.git"
-version = "0.5.3"
+version = "0.6.0"
 
 [deps]
 BasicPOMCP = "d721219e-3fc6-5570-a8ef-e5402f47c49e"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pkg> add AdaOPS
 
 ## Usage
 ```julia
-using POMDPs, POMDPModels, POMDPSimulators, AdaOPS
+using POMDPs, POMDPModels, POMDPTools, AdaOPS
 
 pomdp = TigerPOMDP()
 
@@ -94,7 +94,7 @@ When using rollout-base bounds, you can specify `max_depth` keyword argument to 
 For the `BabyPOMDP` from `POMDPModels`, bounds setup might look like this:
 ```julia
 using POMDPModels
-using POMDPPolicies
+using POMDPTools
 using BasicPOMCP
 
 always_feed = FunctionPolicy(b->true)
@@ -116,7 +116,7 @@ solver = AdaOPSSolver(bounds=IndependentBounds(lower, upper))
 [D3Trees.jl](https://github.com/sisl/D3Trees.jl) can be used to visualize the search tree, for example
 
 ```julia
-using POMDPs, POMDPModels, POMDPModelTools, D3Trees, AdaOPS
+using POMDPs, POMDPModels, POMDPTools, D3Trees, AdaOPS
 
 pomdp = TigerPOMDP()
 
@@ -133,7 +133,7 @@ will create an interactive tree.
 Two utilities, namely `info_analysis` and `hist_analysis`, are provided for getting a sense of how the algorithm is working.
 `info_analysis` takes the infomation returned from `action_info(planner, b0)`. It will first visualize the tree if the `tree_in_info` option is turned on. Then it will show stats such as number nodes expanded, total explorations, average observation branches, and so on. `hist_analysis` takes the `hist` from `HistoryRecorder` simulator. It will show similar stats as `info_analysis` but in the form of figures. It should be noted that `HistoryRecoder` will store the tree of each single step, which makes it memory-intensive. An example is shown as follows.
 ```julia
-using POMDPs, AdaOPS, RockSample, POMDPSimulators, ParticleFilters, POMDPModelTools
+using POMDPs, AdaOPS, RockSample,ParticleFilters, POMDPTools
 
 m = RockSamplePOMDP(11, 11)
 
@@ -155,7 +155,7 @@ a, info = action_info(adaops, b0)
 info_analysis(info)
 
 num_particles = 30000
-@time hist = simulate(HistoryRecorder(max_steps=90), m, adaops, SIRParticleFilter(m, num_particles), b0, s0)
+@time hist = simulate(HistoryRecorder(max_steps=90), m, adaops, BootstrapFilter(m, num_particles), b0, s0)
 hist_analysis(hist)
 @show undiscounted_reward(hist)
 ```

--- a/src/AdaOPS.jl
+++ b/src/AdaOPS.jl
@@ -1,15 +1,13 @@
 module AdaOPS
 
 using POMDPs
-using BeliefUpdaters
+using POMDPTools
 using Parameters
 using CPUTime
 using ParticleFilters
 using D3Trees
 using Random
 using Printf
-using POMDPModelTools
-using POMDPSimulators
 using POMDPLinter
 using LinearAlgebra
 using Distances
@@ -136,7 +134,7 @@ Further information can be found in the field docstrings (e.g.
     "If true, sanity checks on the provided bounds are performed."
     bounds_warnings::Bool                   = false
 
-    "If true, a reprenstation of the constructed DESPOT is returned by POMDPModelTools.action_info."
+    "If true, a reprenstation of the constructed DESPOT is returned by POMDPTools.action_info."
     tree_in_info::Bool                      = false
 
     "Issue an warning when the planning time surpass the time limit by `timeout_warning_threshold` times"

--- a/src/pomdps_glue.jl
+++ b/src/pomdps_glue.jl
@@ -1,6 +1,6 @@
 POMDPs.solve(sol::AdaOPSSolver, p::POMDP) = AdaOPSPlanner(sol, p)
 
-function POMDPModelTools.action_info(p::AdaOPSPlanner{S,A}, b) where {S,A}
+function POMDPTools.action_info(p::AdaOPSPlanner{S,A}, b) where {S,A}
     info = Dict{Symbol, Any}()
     sol = solver(p)
     try
@@ -34,7 +34,7 @@ end
 POMDPs.action(p::AdaOPSPlanner{S,A}, b) where {S,A} = first(action_info(p, b))::A
 function POMDPs.updater(p::AdaOPSPlanner)
     sol = solver(p)
-    SIRParticleFilter(p.pomdp, sol.m_max*50, rng=p.rng)
+    BootstrapFilter(p.pomdp, sol.m_max*50, p.rng)
 end
 
 function Random.seed!(p::AdaOPSPlanner, seed)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,14 +2,11 @@ using AdaOPS
 using Test
 
 using POMDPs
+using POMDPTools
 using POMDPModels
-using POMDPSimulators
 using Random
-using POMDPModelTools
 using ParticleFilters
-using BeliefUpdaters
 using StaticArrays
-using POMDPPolicies
 using Plots
 theme(:mute)
 
@@ -127,7 +124,7 @@ hist_analysis(hist)
 println("Discounted reward is $(discounted_reward(hist))")
 
 # from README:
-using POMDPs, POMDPModels, POMDPSimulators, AdaOPS
+using POMDPs, POMDPModels, POMDPTools, AdaOPS
 
 pomdp = TigerPOMDP()
 


### PR DESCRIPTION
- Updated `AdaOPS` to use POMDPTools instead of the older, deprecated packages (e.g. BeliefUpdaters, POMDPModelTools, POMDPSimulators, POMDPPolicies)
- Bumped compat requirements of BasicPOMCP and MCTS. Older versions had errors that have been resolved and have also migrated to POMDPTools
- Replaced SIRParticleFilter with BootstrapFilter. SIRParticleFilter is being deprecated and outputs a deprecation warning.
- Updated the readme for POMDPTools and BootstrapFilter references
- Added `Manifest.toml`, `.vscode`, and `test/gr-temp` to `.gitignore`
- Version bump to v0.6.0 based on compact changes to MCTS and BasicBOMCP